### PR TITLE
add raw json search

### DIFF
--- a/src/main/kotlin/com/jillesvangurp/eskotlinwrapper/MapBackedProperties.kt
+++ b/src/main/kotlin/com/jillesvangurp/eskotlinwrapper/MapBackedProperties.kt
@@ -21,7 +21,7 @@ interface IMapBackedProperties : MutableMap<String, Any> {
  */
 @Suppress("UNCHECKED_CAST")
 @MapPropertiesDSLMarker
-open class MapBackedProperties internal constructor(
+open class MapBackedProperties(
     internal val _properties: MutableMap<String, Any> = mutableMapOf()
 ) : MutableMap<String, Any> by _properties, ToXContent, IMapBackedProperties {
 

--- a/src/main/kotlin/org/elasticsearch/action/search/KotlinExtensions.kt
+++ b/src/main/kotlin/org/elasticsearch/action/search/KotlinExtensions.kt
@@ -20,7 +20,7 @@ import java.util.function.Supplier
 
 private val logger: KLogger = KotlinLogging.logger { }
 
-private val LOGGING_DEPRECATION_HANDLER: DeprecationHandler = object : DeprecationHandler {
+val LOGGING_DEPRECATION_HANDLER: DeprecationHandler = object : DeprecationHandler {
     override fun usedDeprecatedName(
         parserName: String?,
         location: Supplier<XContentLocation>?,
@@ -91,6 +91,7 @@ fun SearchRequest.source(reader: Reader, deprecationHandler: DeprecationHandler 
 fun SearchRequest.configure(pretty: Boolean = false, block: SearchDSL.() -> Unit): SearchDSL {
     val searchDSL = SearchDSL()
     block.invoke(searchDSL)
+    searchDSL.toString()
     val query = searchDSL.stringify(pretty)
     source(query)
     return searchDSL

--- a/src/test/kotlin/com/jillesvangurp/eskotlinwrapper/AsyncIndexRepositoryTest.kt
+++ b/src/test/kotlin/com/jillesvangurp/eskotlinwrapper/AsyncIndexRepositoryTest.kt
@@ -3,6 +3,8 @@ package com.jillesvangurp.eskotlinwrapper
 import assertk.assertThat
 import assertk.assertions.isEqualTo
 import assertk.assertions.isNull
+import com.jillesvangurp.eskotlinwrapper.dsl.SearchDSL
+import com.jillesvangurp.eskotlinwrapper.dsl.matchAll
 import kotlinx.coroutines.Deferred
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.async
@@ -103,6 +105,22 @@ class AsyncIndexRepositoryTest : AbstractAsyncElasticSearchTest(indexPrefix = "c
                 }
             }.mappedHits.count()
             assertThat(count).isEqualTo(100)
+        }
+    }
+
+    @Test
+    fun `asyn raw json test`() {
+        runBlocking {
+            repository.bulk {
+                (1..10).forEach {
+                    index("$it", TestModel("m-$it"))
+                }
+            }
+            repository.refresh()
+            val results = repository.jsonSearch(SearchDSL().apply {
+                query = matchAll()
+            }.toString())
+            assertThat(results.total).isEqualTo(10)
         }
     }
 }


### PR DESCRIPTION
Workaround for a problem with the java rest high level client where it parses and rejects a valid geo_shape query because apparently that is not supported in the client. The actual json query is fine.

The workaround uses the low level client to send a json string and then parses the response into the usual SearchResponse using XContent.

I may work on this workaround some more as client side XContent juggling before sending the request is kind of redundant in any case. In any case the exception is less informative than any bad request coming from the server.

For now this should be considered experimental.