### PR TITLE
Allow to use pipeline during the index process

### DIFF
--- a/src/main/kotlin/com/jillesvangurp/eskotlinwrapper/IndexRepository.kt
+++ b/src/main/kotlin/com/jillesvangurp/eskotlinwrapper/IndexRepository.kt
@@ -131,7 +131,8 @@ class IndexRepository<T : Any>(
         seqNo: Long? = null,
         primaryTerm: Long? = null,
         refreshPolicy: WriteRequest.RefreshPolicy = WriteRequest.RefreshPolicy.NONE,
-        requestOptions: RequestOptions = this.defaultRequestOptions
+        requestOptions: RequestOptions = this.defaultRequestOptions,
+        pipeline: String? = null
     ): IndexResponse {
         val indexRequest = IndexRequest()
             .index(indexWriteAlias)
@@ -142,6 +143,9 @@ class IndexRepository<T : Any>(
                     it.id(id).create(create)
                 } else {
                     it
+                }
+                if (pipeline != null) {
+                    it.pipeline = pipeline
                 }
             }
 


### PR DESCRIPTION
Hi!

Sometimes we are interested to use a pipeline during the PUT action to index a new document, right now to allow use it in Kotlin, I need to create this code:

        val modelReaderAndWriter = com.jillesvangurp.eskotlinwrapper.JacksonModelReaderAndWriter.create<File>()
        val indexRequest = IndexRequest()
            .index(repository.indexWriteAlias)
            .source(modelReaderAndWriter.serialize(file), XContentType.JSON)
            .let {
                it.refreshPolicy = WriteRequest.RefreshPolicy.NONE
                it.pipeline = pipeline
                it.id(file.token()).create(false)
            }

        esClient.index(indexRequest, RequestOptions.DEFAULT)

But, It could be easier if the index method allow to use a new parameter to set the pipeline property.

For example:

        repository.index(id = file.token(), obj = file, create = false, pipeline = "attachments")

Thanks