### PR TITLE
Add support for filter source

### DIFF
--- a/src/main/kotlin/com/jillesvangurp/eskotlinwrapper/dsl/filter-source.kt
+++ b/src/main/kotlin/com/jillesvangurp/eskotlinwrapper/dsl/filter-source.kt
@@ -1,0 +1,31 @@
+package com.jillesvangurp.eskotlinwrapper.dsl
+
+import kotlin.reflect.KProperty
+
+class SourceBuilder {
+    internal val sourceFilter = mutableMapOf<String, Any>()
+
+    fun includes(vararg fields: KProperty<*>) = includes(*fields.map { it.name }.toTypedArray())
+    fun includes(vararg fields: String) = sourceFilter.set("includes", arrayOf(*fields))
+
+    fun excludes(vararg fields: KProperty<*>) = excludes(*fields.map { it.name }.toTypedArray())
+    fun excludes(vararg fields: String) = sourceFilter.set("excludes", arrayOf(*fields))
+}
+
+fun SearchDSL.filterSource(returnSource: Boolean) {
+    this["_source"] = returnSource
+}
+
+fun SearchDSL.filterSource(vararg fields: KProperty<*>) {
+    this["_source"] = arrayOf(*fields.map { it.name }.toTypedArray())
+}
+
+fun SearchDSL.filterSource(vararg fields: String) {
+    this["_source"] = arrayOf(*fields)
+}
+
+fun SearchDSL.filterSource(block: SourceBuilder.() -> Unit) {
+    val builder = SourceBuilder()
+    block.invoke(builder)
+    this["_source"] = builder.sourceFilter
+}

--- a/src/test/kotlin/com/jillesvangurp/eskotlinwrapper/SearchDSLTest.kt
+++ b/src/test/kotlin/com/jillesvangurp/eskotlinwrapper/SearchDSLTest.kt
@@ -27,6 +27,7 @@ import com.jillesvangurp.eskotlinwrapper.dsl.TermsQuery
 import com.jillesvangurp.eskotlinwrapper.dsl.ZeroTermsQuery
 import com.jillesvangurp.eskotlinwrapper.dsl.bool
 import com.jillesvangurp.eskotlinwrapper.dsl.boosting
+import com.jillesvangurp.eskotlinwrapper.dsl.filterSource
 import com.jillesvangurp.eskotlinwrapper.dsl.matchAll
 import com.jillesvangurp.eskotlinwrapper.dsl.sort
 import org.elasticsearch.action.search.configure
@@ -225,6 +226,35 @@ class SearchDSLTest : AbstractElasticSearchTest(indexPrefix = "search", createIn
                 must(
                     MatchQuery("title", "foo")
                 )
+            }
+        }
+    }
+
+    @Test
+    fun `should construct source filter with boolean`() {
+        val s = SearchDSL()
+        s.apply {
+            filterSource(true)
+        }
+        assertThat(s["_source"]).isEqualTo(true)
+    }
+
+    @Test
+    fun `should construct source filter with a list of fields`() {
+        val fields = arrayOf("foo", "bar")
+        val s = SearchDSL()
+        s.apply {
+            filterSource(*fields)
+        }
+        assertThat(s["_source"] as Array<String>).isEqualTo(fields)
+    }
+
+    @Test
+    fun `should construct source filter with include and exclude`() {
+        testQuery {
+            filterSource {
+                includes("foo", "bar")
+                excludes("baz")
             }
         }
     }


### PR DESCRIPTION
Solves #55 

This PR supports the following cases for [source filtering](https://www.elastic.co/guide/en/elasticsearch/reference/7.12/search-fields.html#source-filtering):

- source filtering enabled disabled
```json
"_source": true
```

```kotlin
filterSource(true)
```

- source filtering with simple field list
```json
"_source": [ "foo", "bar" ]
```

```kotlin
filterSource("foo", "bar")
// or
filterSource(MyClass::foo, MyClass::bar)
```

- source filtering with includes/excludes
```json
"_source": {
  "includes": [ "foo", "bar"  ],
  "excludes": [ "baz" ]
}
```

```kotlin
filterSource {
    includes("foo", "bar")
    excludes("baz")
}
// or
filterSource {
    includes(MyClass::foo, MyClass::bar)
    excludes(MyClass::baz)
}
```

Where possible list of fields can be passed both as strings and `KProperty`s.