### PR TITLE
Fix build

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -7,8 +7,13 @@ import org.jetbrains.kotlin.gradle.tasks.KotlinCompile
 
 buildscript {
     repositories {
-        jcenter()
-        maven(url = "https://jitpack.io")
+        mavenCentral()
+        maven("https://jitpack.io") {
+            content {
+                includeGroup("com.github.jillesvangurp")
+                includeGroup("com.github.jillesvangurp.es-kotlin-codegen-plugin")
+            }
+        }
     }
     dependencies {
         classpath("com.github.jillesvangurp:es-kotlin-codegen-plugin:7.13.0.0")
@@ -28,8 +33,12 @@ plugins {
 apply(plugin = "com.github.jillesvangurp.codegen")
 
 repositories {
-    jcenter()
-    maven(url = "https://jitpack.io")
+    mavenCentral()
+    maven(url = "https://jitpack.io") {
+        content {
+            includeGroup("com.github.jillesvangurp")
+        }
+    }
 }
 
 sourceSets {


### PR DESCRIPTION
See https://github.com/ben-manes/gradle-versions-plugin/issues/541 and
https://github.com/jitpack/jitpack.io/issues/4636

In general it's better to use jitpack only when necessary and
mavenCentral as a general purpose repository due to jitpack being a
potential attack vector

Also jcenter is deprecated so switch to mavenCentral